### PR TITLE
【修正】エラーになってもトーストが出てしまいそうなので確認してみると良さそうです。(優先度: 中) #30

### DIFF
--- a/src/components/MovieInfo.tsx
+++ b/src/components/MovieInfo.tsx
@@ -77,6 +77,8 @@ const MovieInfo = ({ movie, movieListStatusData }: Props) => {
   }, [refetch, dispatch, movies])
 
   useEffect(() => {
+    if (!uid) return
+
     dispatch(fetchRegisteredMovies(uid))
   }, [dispatch, uid])
 

--- a/src/components/MovieInfo.tsx
+++ b/src/components/MovieInfo.tsx
@@ -32,10 +32,7 @@ const MovieInfo = ({ movie, movieListStatusData }: Props) => {
     (state: RootState) => state.movies.movieListData,
   )
 
-  let uid = ''
-  if (user) {
-    uid = user.uid
-  }
+  const uid = user?.uid
 
   const watcedAt = movies[movie.id]?.watchedAt || null
 
@@ -96,19 +93,23 @@ const MovieInfo = ({ movie, movieListStatusData }: Props) => {
           </li>
         ))}
       </ul>
-      <Tooltips
-        onToggleFavorites={onToggleFavorites}
-        onToggleWatchlists={onToggleWatchlists}
-        onToggleModal={onToggleModal}
-        movieListStatus={userLists}
-      />
-      <Modal
-        movieId={movieId}
-        toggle={toggle}
-        stack={stack}
-        uid={uid}
-        watcedAt={watcedAt}
-      />
+      {uid && (
+        <>
+          <Tooltips
+            onToggleFavorites={onToggleFavorites}
+            onToggleWatchlists={onToggleWatchlists}
+            onToggleModal={onToggleModal}
+            movieListStatus={userLists}
+          />
+          <Modal
+            movieId={movieId}
+            toggle={toggle}
+            stack={stack}
+            uid={uid}
+            watcedAt={watcedAt}
+          />
+        </>
+      )}
     </>
   )
 }

--- a/src/components/MovieInfo.tsx
+++ b/src/components/MovieInfo.tsx
@@ -31,6 +31,7 @@ const MovieInfo = ({ movie, movieListStatusData }: Props) => {
   const movies: Record<string, MovieItem> = useSelector(
     (state: RootState) => state.movies.movieListData,
   )
+
   let uid = ''
   if (user) {
     uid = user.uid
@@ -43,15 +44,15 @@ const MovieInfo = ({ movie, movieListStatusData }: Props) => {
   const movieId = movie.id.toString()
 
   const refetch = useCallback(async () => {
-    if (!user) return
+    if (!uid) return
 
     const res = await checkMovieInUserLists(movieId, uid)
 
     setUserLists(res)
-  }, [user, movieId, uid])
+  }, [movieId, uid])
 
   const onToggleFavorites = async () => {
-    if (!user) return
+    if (!uid) return
     await dispatch(toggleFavorites({ movieId, uid: uid }))
 
     await refetch()
@@ -60,7 +61,8 @@ const MovieInfo = ({ movie, movieListStatusData }: Props) => {
   }
 
   const onToggleWatchlists = async () => {
-    if (!user) return
+    if (!uid) return
+
     await dispatch(toggleWatchlists({ movieId, uid: uid }))
 
     await refetch()

--- a/src/components/UserLists.tsx
+++ b/src/components/UserLists.tsx
@@ -26,11 +26,18 @@ const UserLists = ({ movies }: Props) => {
     setInputedComment(comment || '')
   }
 
-  const confirmEdit = (movieId: string, uid: string) => {
-    dispatch(updateComment({ movieId, uid, comment: inputedComment }))
-    setEdittingMovieId(null)
+  const confirmEdit = async (movieId: string, uid: string) => {
+    const res = await dispatch(
+      updateComment({ movieId, uid, comment: inputedComment }),
+    )
 
-    toast.success('コメントを編集しました', toastConfig)
+    if (updateComment.fulfilled.match(res)) {
+      toast.success('コメントを編集しました', toastConfig)
+    } else {
+      toast.error('コメントの編集に失敗しました', toastConfig)
+    }
+
+    setEdittingMovieId(null)
   }
 
   const cancelEdit = () => {

--- a/src/components/UserLists.tsx
+++ b/src/components/UserLists.tsx
@@ -34,8 +34,8 @@ const UserLists = ({ movies }: Props) => {
   }
 
   const cancelEdit = () => {
-    setEdittingMovieId(null)
     if (window.confirm('編集をキャンセルしますか？')) {
+      setEdittingMovieId(null)
       setInputedComment('')
       toast.error('編集をキャンセルしました', toastConfig)
     } else {

--- a/src/lib/features/movies/moviesSlice.ts
+++ b/src/lib/features/movies/moviesSlice.ts
@@ -10,7 +10,6 @@ import {
   Timestamp,
   updateDoc,
 } from 'firebase/firestore'
-import { watch } from 'fs'
 
 import { db } from '@/lib/firebase/firebase'
 import { MovieItem } from '@/types/Movie'
@@ -89,7 +88,7 @@ export const fetchRegisteredMovies = createAsyncThunk<
     return movieListData
   } catch (error: any) {
     console.error('Error is ', error)
-    return rejectWithValue({ message: 'Failed to fetch user lists', error })
+    return rejectWithValue(error)
   }
 })
 
@@ -131,10 +130,8 @@ export const fetchRegisteredLists = createAsyncThunk<
 
     return listDataObject
   } catch (error: any) {
-    return rejectWithValue({
-      message: 'Failed to fetch user lists',
-      error,
-    })
+    console.error('Error is ', error)
+    return rejectWithValue(error)
   }
 })
 
@@ -168,7 +165,8 @@ export const toggleFavorites = createAsyncThunk<
       return { movieId, uid, formattedCreatedAt }
     }
   } catch (error: any) {
-    return rejectWithValue('Error happened')
+    console.error('Error is ', error)
+    return rejectWithValue(error)
   }
 })
 
@@ -202,7 +200,8 @@ export const toggleWatchlists = createAsyncThunk<
       return { movieId, uid, formattedCreatedAt }
     }
   } catch (error: any) {
-    return rejectWithValue('Error happened')
+    console.error('Error is ', error)
+    return rejectWithValue(error)
   }
 })
 
@@ -210,16 +209,16 @@ export const updateComment = createAsyncThunk<
   { movieId: string; comment: string },
   { movieId: string; comment: string; uid: string },
   { rejectValue: string }
->('updateComment', async ({ movieId, comment, uid }) => {
+>('updateComment', async ({ movieId, comment, uid }, { rejectWithValue }) => {
   try {
     const userListRef = doc(db, 'users', uid)
     const movieRef = doc(userListRef, 'movies', movieId)
 
     await updateDoc(movieRef, { comment })
-
     return { movieId, comment }
   } catch (error: any) {
-    throw error
+    console.error('Error is ', error)
+    return rejectWithValue(error)
   }
 })
 
@@ -261,7 +260,7 @@ export const regisrerWatched = createAsyncThunk<
       }
     } catch (error: any) {
       console.error('Error is ', error)
-      return rejectWithValue('Error happened')
+      return rejectWithValue(error)
     }
   },
 )

--- a/src/lib/features/movies/moviesSlice.ts
+++ b/src/lib/features/movies/moviesSlice.ts
@@ -210,7 +210,7 @@ export const updateComment = createAsyncThunk<
   { movieId: string; comment: string },
   { movieId: string; comment: string; uid: string },
   { rejectValue: string }
->('updateComment', async ({ movieId, comment, uid }, { rejectWithValue }) => {
+>('updateComment', async ({ movieId, comment, uid }) => {
   try {
     const userListRef = doc(db, 'users', uid)
     const movieRef = doc(userListRef, 'movies', movieId)
@@ -219,8 +219,7 @@ export const updateComment = createAsyncThunk<
 
     return { movieId, comment }
   } catch (error: any) {
-    console.error('Error is ', error)
-    return rejectWithValue('Error happened')
+    throw error
   }
 })
 


### PR DESCRIPTION
#30 の修正

## issue内容
[エラーになってもトーストが出てしまいそうなので確認してみると良さそうです。(優先度: 中) #30](https://github.com/canopus-m-satoshi/movie-app/issues/30)

## 達成条件
エラー時用のトーストを用意する

## 作業ファイル

[src/components/UserLists.tsx](https://github.com/canopus-m-satoshi/movie-app/compare/fix/issues?expand=1#diff-b0104ffcb3cc3cc201ff8eb87761ed2c5b796374da033d008b49a929eb6db973)

src/lib/features/movies/moviesSlice.ts

## 変更内容

- updateComment.fulfilled.match(result)` を使用して、非同期処理の成功/失敗を判定し、適切なトーストメッセージを表示するよう修正
  - 成功時："コメントを編集しました" というトーストメッセージが表示
  - 失敗時："コメントの編集に失敗しました" というトーストメッセージが表示

- action creator 'updateComment'において、エラー時にrejectWithValueを返していたがerrorを返すように変更

## 確認したいこと

- コメント記述いたしました。
https://github.com/canopus-m-satoshi/movie-app/pull/48/files/3ff23f81b184bceab8d96c8788b4caf862263f95

## Issue 30 関連以外の修正
5590db3a3dcf79d50d76ff86bf782d803c965e30 - MovieInfo.tsxのfetchRegisteredMoviesをdispatch時にnullチェックを追記
fa185988d46643a41c938f980d275626f8ac9a4e - MovieInfo.tsxの微修正
70064d521b1fb23668ee684421a39598decf722b - UserLists.tsxのコメント入力キャンセル時の挙動を修正