### PR TITLE
issue #29の対応(AuthProviderのリネーム)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,6 @@ import { ToastContainer } from 'react-toastify'
 
 import Footer from '../components/Footer'
 import Header from '../components/Header'
-import AuthProvider from '../provider/AuthProvider'
 import StoreProvider from '../provider/StoreProvider'
 
 export const metadata: Metadata = {
@@ -16,6 +15,9 @@ export const metadata: Metadata = {
 import 'react-toastify/dist/ReactToastify.min.css'
 import 'react-datepicker/dist/react-datepicker.css'
 
+// RTKで管理している認証情報を取得するためのコンポーネント
+import WithAuth from '../components/WithAuth'
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -25,14 +27,14 @@ export default function RootLayout({
     <html lang="jp">
       <body>
         <StoreProvider>
-          <AuthProvider>
+          <WithAuth>
             <div className="flex flex-col min-h-screen">
               <Header />
               <div className="flex-grow bg-slate-100">{children}</div>
               <Footer />
               <ToastContainer />
             </div>
-          </AuthProvider>
+          </WithAuth>
         </StoreProvider>
       </body>
     </html>

--- a/src/components/WithAuth.tsx
+++ b/src/components/WithAuth.tsx
@@ -6,16 +6,12 @@ import { useDispatch } from 'react-redux'
 import { checkAuthStatus } from '@/lib/features/auth/authSlice'
 import { AppDispatch } from '@/lib/store'
 
-export default function AuthProvider({
-  children,
-}: {
-  children: React.ReactNode
-}) {
+export default function WithAuth({ children }: { children: React.ReactNode }) {
   const dispatch: AppDispatch = useDispatch()
 
   useEffect(() => {
     dispatch(checkAuthStatus())
   }, [dispatch])
 
-  return <div>{children}</div>
+  return <>{children}</>
 }


### PR DESCRIPTION
WithAuthにリネームし、コンポーネントディレクトリに移動