### PR TITLE
UserMenuをNavMenuにリネーム

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 
 import Loading from './Loading'
 import Logo from './Logo'
-import UserMenu from './UserMenu'
+import NavMenu from './NavMenu'
 
 const Header = () => {
   return (
@@ -11,7 +11,7 @@ const Header = () => {
         <Suspense fallback={<Loading />}>
           <Logo />
         </Suspense>
-        <UserMenu />
+        <NavMenu />
       </div>
     </header>
   )

--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -13,7 +13,7 @@ import { signOutUser } from '@/lib/features/auth/authSlice'
 import { AppDispatch, RootState } from '@/lib/store'
 import { toastConfig } from '@/lib/toastConfig'
 
-const UserMenu = () => {
+const NavMenu = () => {
   const dispatch: AppDispatch = useDispatch()
   const router = useRouter()
 
@@ -86,4 +86,4 @@ const UserMenu = () => {
     </div>
   )
 }
-export default UserMenu
+export default NavMenu


### PR DESCRIPTION
User〇〇というコンポーネントはユーザーページ関連用で統一したいため